### PR TITLE
feat: live speed and ETA for upload and zipping

### DIFF
--- a/internal/core/queue/queue.go
+++ b/internal/core/queue/queue.go
@@ -520,7 +520,11 @@ func (q *DownloadQueue) runTask(task *DownloadTask, t *torrent.Torrent, u *api.A
 			if task.Request.IsZipped {
 				zipPath := originalPath + ".zip"
 				log.Printf("Zipping folder %s to %s", originalPath, zipPath)
-				var lastZipEmit time.Time
+				var (
+					lastZipEmit  time.Time
+					lastZipBytes int64
+					zipSampled   bool
+				)
 				calculateZipProgress := func(readByte, totalByte int64) {
 					var progress float64 = 0
 					if totalByte > 0 {
@@ -535,15 +539,26 @@ func (q *DownloadQueue) runTask(task *DownloadTask, t *torrent.Torrent, u *api.A
 					if time.Since(lastZipEmit) < ws.ProgressBroadcastInterval && readByte < totalByte {
 						return
 					}
+					speed := "-"
+					eta := "calculating..."
+					if zipSampled {
+						if dt := time.Since(lastZipEmit).Seconds(); dt > 0 {
+							bps := float64(readByte-lastZipBytes) / dt
+							speed = formatSpeed(bps)
+							eta = etaFromRate(readByte, totalByte, bps)
+						}
+					}
 					lastZipEmit = time.Now()
+					lastZipBytes = readByte
+					zipSampled = true
 					wm.SendProgress(ws.TorrentUpdate{
 						Type:           "torrent update",
 						ID:             infoHash,
 						Name:           t.Info().Name,
 						Status:         StatusZipping,
 						Progress:       progress,
-						Speed:          "-",
-						ETA:            "--:--",
+						Speed:          speed,
+						ETA:            eta,
 						TotalSize:      totalByte,
 						BytesCompleted: readByte,
 						UserID:         task.Request.UserID,
@@ -724,6 +739,18 @@ func calculateETA(t *torrent.Torrent) string {
 	duration := time.Duration(seconds) * time.Second
 
 	return formatDuration(duration)
+}
+
+// etaFromRate estimates remaining time given a byte rate.
+func etaFromRate(completed, total int64, bytesPerSec float64) string {
+	if total <= 0 || bytesPerSec <= 0 {
+		return "calculating..."
+	}
+	if completed >= total {
+		return "complete"
+	}
+	seconds := float64(total-completed) / bytesPerSec
+	return formatDuration(time.Duration(seconds) * time.Second)
 }
 
 // formatSpeed converts bytes per second to human readable format

--- a/internal/core/upload/upload.go
+++ b/internal/core/upload/upload.go
@@ -83,6 +83,38 @@ func returnPercentageCompleted(c, t int64) float64 {
 	return math.Round(percentage*100) / 100
 }
 
+func formatSpeed(bytesPerSec float64) string {
+	if bytesPerSec < 1024 {
+		return fmt.Sprintf("%.2f B/s", bytesPerSec)
+	}
+	value := bytesPerSec / 1024
+	if value < 1024 {
+		return fmt.Sprintf("%.2f KB/s", value)
+	}
+	return fmt.Sprintf("%.2f MB/s", value/1024.0)
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	} else if d < time.Hour {
+		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
+}
+
+// etaFromRate estimates remaining time given a byte rate.
+func etaFromRate(completed, total int64, bytesPerSec float64) string {
+	if total <= 0 || bytesPerSec <= 0 {
+		return "calculating..."
+	}
+	if completed >= total {
+		return "complete"
+	}
+	seconds := float64(total-completed) / bytesPerSec
+	return formatDuration(time.Duration(seconds) * time.Second)
+}
+
 // SendTorrentToServerWithProgress uploads a torrent to the server with progress tracking
 func SendTorrentToServerWithProgress(
 	folderPath string,
@@ -107,22 +139,37 @@ func SendTorrentToServerWithProgress(
 		ETA:      "starting upload...",
 		UserID:   userID,
 	})
-	var lastUploadEmit time.Time
+	var (
+		lastUploadEmit  time.Time
+		lastUploadBytes int64
+		uploadSampled   bool
+	)
 	callbackfunc := func(uploadedByte, totalByte int64) {
 		// Throttle to the shared broadcast cadence so uploads tick at the same
 		// rate as downloads (but always emit the final byte).
 		if time.Since(lastUploadEmit) < ws.ProgressBroadcastInterval && uploadedByte < totalByte {
 			return
 		}
+		speed := "-"
+		eta := "calculating..."
+		if uploadSampled {
+			if dt := time.Since(lastUploadEmit).Seconds(); dt > 0 {
+				bps := float64(uploadedByte-lastUploadBytes) / dt
+				speed = formatSpeed(bps)
+				eta = etaFromRate(uploadedByte, totalByte, bps)
+			}
+		}
 		lastUploadEmit = time.Now()
+		lastUploadBytes = uploadedByte
+		uploadSampled = true
 		tracker.websocketMgr.SendProgress(ws.TorrentUpdate{
 			Type:           "torrent update",
 			ID:             tracker.torrentID,
 			Name:           tracker.torrentName,
 			Status:         "uploading",
 			Progress:       returnPercentageCompleted(uploadedByte, totalByte),
-			Speed:          "-",
-			ETA:            "uploading...",
+			Speed:          speed,
+			ETA:            eta,
 			TotalSize:      totalByte,
 			BytesCompleted: uploadedByte,
 			UserID:         userID,


### PR DESCRIPTION
## What

Upload and zip progress previously emitted hardcoded placeholders (`Speed: "-"`, `ETA: "uploading..."`/`"--:--"`) — they never showed a real rate or time-left, unlike downloads. This computes both from the bytes-over-time already passed to each progress callback.

## Changes

- **Upload** (`internal/core/upload/upload.go`): the progress callback now tracks bytes between emits and reports a live `Speed` and `ETA`. Added local `formatSpeed`/`formatDuration`/`etaFromRate` helpers (upload can't import queue — would be an import cycle).
- **Zipping** (`internal/core/queue/queue.go`): `calculateZipProgress` now reports live `Speed` and `ETA` based on bytes read from source; added shared `etaFromRate` helper next to the existing formatters.

Both keep the existing broadcast-cadence throttling; the first tick shows "calculating..." until there's a sample to measure a rate from.

